### PR TITLE
Fixed issues with query selector

### DIFF
--- a/firefox.sh
+++ b/firefox.sh
@@ -4,6 +4,7 @@ rm -rf firefox
 mkdir firefox
 cp manifest-ff.json firefox/manifest.json
 cp reader.js firefox
+cp style.css firefox
 cat background.js | sed -e 's/action/browserAction/g' > firefox/background.js
 cp -r icons firefox
 curl https://unpkg.com/webextension-polyfill@0.9.0/dist/browser-polyfill.min.js > firefox/browser-polyfill.js

--- a/reader.js
+++ b/reader.js
@@ -24,7 +24,7 @@ function boldifyText() {
                         const l = Math.ceil(x.length / 2);
                         return `<b>${x.substring(0, l)}</b>${x.substring(l)}`;
                     })
-                    .replace(/(\d+)/g, '<b>$1</b>');
+                    .replace(/(\d+|[!-\/:-@\[-`\{-~]+)/g, '<b>$1</b>');
                 nodes[i].removeChild(child);
                 nodes[i].appendChild(newNode);
             }

--- a/reader.js
+++ b/reader.js
@@ -8,7 +8,8 @@ function toggleBold(data) {
 }
 
 function boldifyText() {
-    const nodes = document.body.querySelectorAll('p,h1,h2,h3,h4,li,a,span,div');
+    // Process all nodes that are not "bold" tagged elements
+    const nodes = document.body.querySelectorAll(':not(b)');
     for (let i = 0; i < nodes.length; i++) {
         const children = nodes[i].childNodes.length;
         for (let j = 0; j < children; j++) {
@@ -17,6 +18,7 @@ function boldifyText() {
                 nodes[i].appendChild(child);
             } else {
                 const newNode = document.createElement('span');
+                newNode.classList.add('bi-bold');
                 newNode.innerHTML = child.textContent
                     .replace(/([A-Za-zÀ-ú]+)\b/g, function (x) {
                         const l = Math.ceil(x.length / 2);
@@ -28,6 +30,14 @@ function boldifyText() {
             }
         }
     }
+
+    // Inject bold css
+    const path = chrome.extension.getURL('style.css');
+    const link = document.createElement('link');
+    link.href = path;
+    link.type = 'text/css';
+    link.rel = 'stylesheet';
+    document.getElementsByTagName('head')[0].appendChild(link);
 }
 
 chrome.runtime.onMessage.addListener(toggleBold);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,3 @@
+.bi-bold b {
+    font-weight: 700 !important;
+}


### PR DESCRIPTION
Due to many sites having custom tags, the query selector was missing a lot of element. As a result, many elements were not being highlighted correctly (See #3). Additionally, the italicized text was not being highlighted, which resulted in a weird looking section if an entire section was italicized. All of these issues are going to be fixed by replacing the old queryselector line with the following:

```js
document.body.querySelectorAll(':not(b)')
```

## Resolutions

- Fixes #6 
- Fixes #4 
- Fixes #3 
- Fixes #2 